### PR TITLE
fix: keep edit modals open when a change is rejected

### DIFF
--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -84,18 +84,15 @@ export default function App() {
 
   const { colorScheme, setColorScheme } = useColorScheme();
 
-  if (storage.getString("colorScheme")) {
-    Appearance.setColorScheme(storage.getString("colorScheme") as ColorSchemeName);
-    setColorScheme(storage.getString("colorScheme") as ColorSchemeName);
-  } else {
-    if (Appearance.getColorScheme()) {
-      storage.set("colorScheme", Appearance.getColorScheme());
-      setColorScheme(Appearance.getColorScheme());
-    } else {
-      storage.set("colorScheme", "light");
-      setColorScheme("light");
-    }
-  }
+  useEffect(() => {
+    const savedScheme = storage.getString("colorScheme");
+    const scheme = savedScheme ?? Appearance.getColorScheme() ?? "light";
+
+    if (!savedScheme) storage.set("colorScheme", scheme);
+
+    Appearance.setColorScheme(scheme as ColorSchemeName);
+    setColorScheme(scheme as ColorSchemeName);
+  }, [setColorScheme]);
 
   if (storage.getString("passingPeriods") == "undefined") storage.set("passingPeriods", "true");
 
@@ -110,7 +107,7 @@ export default function App() {
 
   return (
     <>
-      <StatusBar style={storage.getString("colorScheme") == "dark" ? "light" : "dark"} />
+      <StatusBar style={colorScheme == "dark" ? "light" : "dark"} />
       <GestureHandlerRootView style={{ flex: 1 }}>
         <NativeTabs
           backgroundColor={colorScheme == "dark" ? "#000000" : "#ddeff0"}

--- a/apps/mobile/src/app/settings/index.tsx
+++ b/apps/mobile/src/app/settings/index.tsx
@@ -15,7 +15,7 @@ import { impactAsync } from "expo-haptics";
 import { router, usePathname } from "expo-router";
 import { styled, useColorScheme } from "nativewind";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Alert, Platform, Pressable, Switch, Text, View } from "react-native";
+import { Alert, Appearance, Platform, Pressable, Switch, Text, View } from "react-native";
 
 import WidgetUpdaterModule from "@/modules/widget-updater/src/WidgetUpdaterModule";
 import Import from "@/src/app/settings/import";
@@ -199,13 +199,11 @@ export default function Settings() {
             thumbColor="#ddeff0"
             trackColor={{ false: "#bfe0e2", true: "#3b757f" }}
             onValueChange={() => {
-              if (colorScheme == "dark") {
-                setColorScheme("light");
-                storage.set("colorScheme", "light");
-              } else {
-                setColorScheme("dark");
-                storage.set("colorScheme", "dark");
-              }
+              const nextScheme = colorScheme == "dark" ? "light" : "dark";
+
+              storage.set("colorScheme", nextScheme);
+              Appearance.setColorScheme(nextScheme);
+              setColorScheme(nextScheme);
 
               WidgetUpdaterModule.update();
               impactAsync();

--- a/apps/mobile/src/components/settings/AddEventModal.tsx
+++ b/apps/mobile/src/components/settings/AddEventModal.tsx
@@ -14,6 +14,7 @@ import {
 } from "react-native";
 import DateTimePickerModal from "react-native-modal-datetime-picker";
 
+import { findEventConflict } from "@/src/utils/eventValidation";
 import storage from "@/src/utils/storage";
 
 import TextModal from "./TextModal";
@@ -43,16 +44,6 @@ function createCustomDate(timestamp: number) {
   return timeString;
 }
 
-function createCustomTime(inputTime: string) {
-  const currentDate = new Date();
-
-  const [inputHourRaw, inputMinuteRaw] = inputTime.split(":");
-  const inputMinute = inputMinuteRaw.replace(/[A-Za-z]/g, ""); // Remove any non-numeric characters
-
-  currentDate.setHours(parseInt(inputHourRaw), parseInt(inputMinute), 0, 0);
-  return currentDate.getTime();
-}
-
 function sortByStartTime(array: UnparsedEvent[]) {
   return array.sort((a, b) => {
     const startTimeA = a.startTime.split(":").map(Number);
@@ -64,35 +55,6 @@ function sortByStartTime(array: UnparsedEvent[]) {
       return startTimeA[1] - startTimeB[1]; // If hours are the same, sort by minute
     }
   });
-}
-
-function areEventsValid(events: UnparsedEvent[]) {
-  if (events.length <= 1) {
-    return true; // Single event is always valid
-  }
-
-  for (let i = 0; i < events.length; i++) {
-    const currentEvent = events[i];
-
-    const startTime = createCustomTime(currentEvent.startTime);
-    const endTime = createCustomTime(currentEvent.endTime);
-
-    if (startTime >= endTime) {
-      return false; // End time is not after start time
-    }
-
-    if (i < events.length - 1) {
-      // Check for event overlap
-      const nextEvent = events[i + 1];
-      const nextStartTime = createCustomTime(nextEvent.startTime);
-
-      if (endTime > nextStartTime) {
-        return false; // Events overlap
-      }
-    }
-  }
-
-  return true; // All events are valid
 }
 
 function addEvent(
@@ -116,15 +78,15 @@ function addEvent(
     newSchedule["routines"][currentRoutine]["events"],
   );
 
-  if (!areEventsValid(newSchedule["routines"][currentRoutine]["events"])) {
-    return Alert.alert(
-      "Error",
-      "This event overlaps with another event or has an invalid start/end time.",
-    );
-  } else {
-    setSchedule(newSchedule);
-    storage.set("currentSchedule", JSON.stringify(newSchedule));
+  const conflict = findEventConflict(newSchedule["routines"][currentRoutine]["events"]);
+  if (conflict) {
+    Alert.alert("Error", conflict);
+    return false;
   }
+
+  setSchedule(newSchedule);
+  storage.set("currentSchedule", JSON.stringify(newSchedule));
+  return true;
 }
 
 export default function AddEventModal(props: {
@@ -286,7 +248,7 @@ export default function AddEventModal(props: {
             accessibilityLabel="Finish"
             className="mt-3 bg-wedgewood-300 rounded shadow-xl p-4 border-2 border-wedgewood-400 active:bg-wedgewood-500 dark:active:bg-wedgewood-800 flex flex-row items-center justify-center dark:bg-wedgewood-950 dark:border-wedgewood-600"
             onPress={() => {
-              addEvent(
+              const added = addEvent(
                 props.scheduleDB,
                 props.setScheduleDB,
                 props.currentRoutine,
@@ -294,7 +256,8 @@ export default function AddEventModal(props: {
                 createCustomDate(startTime.getTime()),
                 createCustomDate(endTime.getTime()),
               );
-              props.setModalVisible(false);
+
+              if (added) props.setModalVisible(false);
             }}
           >
             <StyledText className="mr-2 font-poppinsBold text-center text-wedgewood-950 dark:text-wedgewood-300">

--- a/apps/mobile/src/components/settings/AddRoutineModal.tsx
+++ b/apps/mobile/src/components/settings/AddRoutineModal.tsx
@@ -29,13 +29,17 @@ function createNewRoutine(
   name: string,
   weekdays: number[],
 ) {
-  if (!name) return Alert.alert("Error", "You must provide a name.");
-
-  const newSchedule = { ...schedule };
-
-  if (newSchedule["routines"][name]) {
-    return Alert.alert("Error", "Routine with same name already exists.");
+  if (!name) {
+    Alert.alert("Error", "You must provide a name.");
+    return false;
   }
+
+  if (schedule["routines"][name]) {
+    Alert.alert("Error", `A routine named "${name}" already exists. Pick a different name.`);
+    return false;
+  }
+
+  const newSchedule = JSON.parse(JSON.stringify(schedule)) as UnparsedSchedule;
 
   newSchedule["routines"][name] = {
     officialName: name,
@@ -55,6 +59,7 @@ function createNewRoutine(
   storage.set("currentSchedule", JSON.stringify(newSchedule));
 
   Alert.alert("Success", "Successfully created a new routine.");
+  return true;
 }
 
 export default function AddRoutineModal(props: {
@@ -138,7 +143,17 @@ export default function AddRoutineModal(props: {
             accessibilityLabel="Finish"
             className="mt-4 bg-wedgewood-300 rounded shadow-xl p-4 border-2 border-wedgewood-400 active:bg-wedgewood-500 dark:active:bg-wedgewood-800 flex flex-row items-center justify-center dark:bg-wedgewood-950 dark:border-wedgewood-600"
             onPress={() => {
-              createNewRoutine(props.scheduleDB, props.setScheduleDB, name, weekdays);
+              const created = createNewRoutine(
+                props.scheduleDB,
+                props.setScheduleDB,
+                name,
+                weekdays,
+              );
+
+              if (!created) return;
+
+              setName("New Routine!");
+              setWeekdays([]);
               props.setModalVisible(false);
             }}
           >

--- a/apps/mobile/src/components/settings/EventModal.tsx
+++ b/apps/mobile/src/components/settings/EventModal.tsx
@@ -14,6 +14,7 @@ import {
 } from "react-native";
 import DateTimePickerModal from "react-native-modal-datetime-picker";
 
+import { findEventConflict } from "@/src/utils/eventValidation";
 import storage from "@/src/utils/storage";
 
 import TextModal from "./TextModal";
@@ -56,45 +57,6 @@ function createCustomDateString(timestamp: number) {
   return timeString;
 }
 
-function createCustomTime(inputTime: string) {
-  const currentDate = new Date();
-
-  const [inputHourRaw, inputMinuteRaw] = inputTime.split(":");
-  const inputMinute = inputMinuteRaw.replace(/[A-Za-z]/g, ""); // Remove any non-numeric characters
-
-  currentDate.setHours(parseInt(inputHourRaw), parseInt(inputMinute), 0, 0);
-  return currentDate.getTime();
-}
-
-function areEventsValid(events: UnparsedEvent[]) {
-  if (events.length <= 1) {
-    return true; // Single event is always valid
-  }
-
-  for (let i = 0; i < events.length; i++) {
-    const currentEvent = events[i];
-
-    const startTime = createCustomTime(currentEvent.startTime);
-    const endTime = createCustomTime(currentEvent.endTime);
-
-    if (startTime >= endTime) {
-      return false; // End time is not after start time
-    }
-
-    if (i < events.length - 1) {
-      // Check for event overlap
-      const nextEvent = events[i + 1];
-      const nextStartTime = createCustomTime(nextEvent.startTime);
-
-      if (endTime > nextStartTime) {
-        return false; // Events overlap
-      }
-    }
-  }
-
-  return true; // All events are valid
-}
-
 function modifyEvent(
   schedule: UnparsedSchedule,
   setSchedule: React.Dispatch<React.SetStateAction<UnparsedSchedule>>,
@@ -127,15 +89,15 @@ function modifyEventTimes(
     newSchedule["routines"][currentRoutine]["events"],
   );
 
-  if (!areEventsValid(newSchedule["routines"][currentRoutine]["events"])) {
-    return Alert.alert(
-      "Error",
-      "This event overlaps with another event or has an invalid start/end time.",
-    );
+  const conflict = findEventConflict(newSchedule["routines"][currentRoutine]["events"]);
+  if (conflict) {
+    Alert.alert("Error", conflict);
+    return false;
   }
 
   setSchedule(newSchedule);
   storage.set("currentSchedule", JSON.stringify(newSchedule));
+  return true;
 }
 
 function removeEvent(
@@ -420,10 +382,7 @@ export default function EventModal(props: {
                 return Alert.alert("Error", "End time must be after start time.");
               }
 
-              props.setStartTime(updatedStartTime);
-              props.setEndTime(updatedEndTime);
-
-              modifyEventTimes(
+              const saved = modifyEventTimes(
                 props.scheduleDB,
                 props.setScheduleDB,
                 props.currentRoutine,
@@ -432,6 +391,10 @@ export default function EventModal(props: {
                 createCustomDateString(updatedEndTime.getTime()),
               );
 
+              if (!saved) return;
+
+              props.setStartTime(updatedStartTime);
+              props.setEndTime(updatedEndTime);
               props.setModalVisible(false);
             }}
           >

--- a/apps/mobile/src/utils/eventValidation.ts
+++ b/apps/mobile/src/utils/eventValidation.ts
@@ -1,0 +1,28 @@
+import { UnparsedEvent } from "@scheduli/types";
+
+function toTimestamp(inputTime: string) {
+  const date = new Date();
+
+  const [hourRaw, minuteRaw] = inputTime.split(":");
+  const minute = minuteRaw.replace(/[A-Za-z]/g, "");
+
+  date.setHours(parseInt(hourRaw), parseInt(minute), 0, 0);
+  return date.getTime();
+}
+
+export function findEventConflict(events: UnparsedEvent[]) {
+  for (let i = 0; i < events.length; i++) {
+    const current = events[i];
+
+    if (toTimestamp(current.startTime) >= toTimestamp(current.endTime)) {
+      return `"${current.name}" has to end after it starts.`;
+    }
+
+    const next = events[i + 1];
+    if (next && toTimestamp(current.endTime) > toTimestamp(next.startTime)) {
+      return `"${current.name}" overlaps with "${next.name}". Change one of their times so they don't run at the same time.`;
+    }
+  }
+
+  return null;
+}


### PR DESCRIPTION
Addresses three friction points reported from within the mobile app.

All three share one root cause on the event/routine side: the modals called `setModalVisible(false)` unconditionally, so a rejected write looked identical to a silent failure — the sheet closed, the user's input was gone, and nothing had changed.

## Event overlaps and invalid times

`AddEventModal` and `EventModal` both dismissed themselves right after calling their save function, whether or not validation passed. The user had to reopen the modal and re-enter the name and both times from scratch, guided only by "This event overlaps with another event or has an invalid start/end time" — which never said *which* event it collided with.

`EventModal` was worse: it called `props.setStartTime` / `props.setEndTime` **before** attempting the save, so a rejected edit left the event row in the routine list displaying times that were never written to storage.

- The duplicated `areEventsValid` / `createCustomTime` pair in both modals is replaced by a shared `findEventConflict` in `src/utils/eventValidation.ts`, which returns the offending pair (`"Lunch" overlaps with "5th Period"…`) instead of a bare boolean.
- Both save functions now return success, and the modal only closes on success.
- `EventModal` applies the new times to the parent only after the save is accepted.

The shared helper also drops the old `events.length <= 1` early return, so a lone event's start/end is checked like any other. Both modals already blocked `start >= end` at the picker and on Finish, so nothing that used to save stops saving.

## Routine missing after creation

`createNewRoutine` rejects a duplicate name, and the pre-filled name is always `"New Routine!"` — so creating a second routine without renaming it hit the duplicate branch, the modal closed anyway, and no routine appeared in the list.

- Failure keeps the modal open; the message names the routine that already exists.
- The form resets after a successful create, so the next routine doesn't start out pre-filled with a name that is now taken.
- `createNewRoutine` deep copies the schedule before mutating. It previously used `{ ...schedule }`, which shares the `routines` object with the existing state, so the pre-update object was mutated in place. The other writers here (`addEvent`, `modifyEventTimes`) already deep copy.

## Dark mode toggle

`app/_layout.tsx` called `Appearance.setColorScheme()` and `setColorScheme()` **in the render body**, on every render. That re-entered render from render and remounted `NativeTabs`, which resets navigation state — the toggle would bounce the user out of the screen they were on, and the re-applied stored value could land back on the scheme they started from.

- Root layout applies the stored scheme once, from an effect.
- The toggle writes storage first, then sets `Appearance` and the nativewind scheme, so nothing re-reads a stale value mid-flight.
- `StatusBar` reads the reactive `colorScheme` instead of `storage.getString(...)`, so it flips with the rest of the UI.

## Not addressed

The countdown-timer engagement note is an observation rather than a defect, so nothing changed there.

## Testing

`bun run lint`, `bun run format`, and `tsc --noEmit` in `apps/mobile` all pass locally, and all CI checks are green on this branch.

The meaningful coverage comes from `test-ios`, which builds the app, boots an iPhone 17 Pro simulator, and runs the whole Maestro suite. Two of those flows exercise this diff directly:

- `darkMode.yaml` toggles dark mode and then walks Settings → General → Back → Routines → Back — the navigation path the render-phase `setColorScheme()` was resetting.
- `editRoutine.yaml` opens an event, renames it, and saves through the `EventModal` Finish button that now gates on the save succeeding.

Worth flagging for reviewers: `test-android` only builds the Android simulator app, it does not run Maestro. So the dark mode fix is verified on iOS but not on Android, where `NativeTabs` and `Appearance` are backed by a different native implementation. The manual repro for that one is: toggle dark mode from a nested settings screen and confirm you stay put and the theme actually flips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XN5J6bUa9anKhYUSfcnpiz